### PR TITLE
Issue/57

### DIFF
--- a/bartender/local_plugins/logger.py
+++ b/bartender/local_plugins/logger.py
@@ -21,17 +21,13 @@ class PluginHandler(object):
 
 
 # Since we are imitating the logging module, we will allow camel case method names
-def getPluginLogger(name, formatted=True, log_directory=None, log_name=None):
-    """
-    Get a Plugin Logger. If formatted is set to true, do no special formatting.
-    Otherwise, make the logger log to something semi-pretty
+def getPluginLogger(name, format_string=None, log_directory=None, log_name=None):
+    """Get a logger for a plugin
 
     Args:
         name (str): The name of the logger to create
-        formatted (str / bool): The formatting to apply to the logger
-            ``True``: Apply normal plugin formatting
-            ``False``: Add no additional formatting, log message as-is
-            ``'timestamp'``: Add timestamp to beginning of log message
+        format_string (str): The format_string to use with the logger
+            If ``None`` then messages will be logged as-is
         log_directory (str, optional): Directory that will hold the log file
             If not given a logger for STDOUT will be constructed
         log_name (str, optional): The name of the log file
@@ -51,17 +47,11 @@ def getPluginLogger(name, formatted=True, log_directory=None, log_name=None):
                                 log_name or name, log_directory)
     else:
         handler = logging.StreamHandler(sys.stdout)
+
     handler.setLevel(logging.INFO)
-
-    if not formatted:
-        format_string = '%(message)s'
-    elif formatted == 'timestamp':
-        format_string = '%(asctime)s - %(message)s'
-    else:
-        format_string = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
     handler.setFormatter(logging.Formatter(format_string))
-
     log.addHandler(handler)
+
     return log
 
 

--- a/bartender/local_plugins/logger.py
+++ b/bartender/local_plugins/logger.py
@@ -1,6 +1,7 @@
 import logging
 import logging.handlers
 import os
+import sys
 
 
 class PluginHandler(object):
@@ -20,14 +21,25 @@ class PluginHandler(object):
 
 
 # Since we are imitating the logging module, we will allow camel case method names
-def getPluginLogger(name, formatted=True, log_directory=None):
+def getPluginLogger(name, formatted=True, log_directory=None, log_name=None):
     """
     Get a Plugin Logger. If formatted is set to true, do no special formatting.
     Otherwise, make the logger log to something semi-pretty
 
-    :param name:
-    :param formatted:
-    :return:
+    Args:
+        name (str): The name of the logger to create
+        formatted (str / bool): The formatting to apply to the logger
+            ``True``: Apply normal plugin formatting
+            ``False``: Add no additional formatting, log message as-is
+            ``'timestamp'``: Add timestamp to beginning of log message
+        log_directory (str, optional): Directory that will hold the log file
+            If not given a logger for STDOUT will be constructed
+        log_name (str, optional): The name of the log file
+            * If ``log_directory`` is not provided this is not used
+            * If not provided the ``name`` value will be used
+
+     Returns:
+        The configured logger instance
     """
     log = logging.getLogger(name)
     log.propagate = False
@@ -35,15 +47,19 @@ def getPluginLogger(name, formatted=True, log_directory=None):
         return log
 
     if log_directory:
-        handler = PluginHandler(logging.handlers.RotatingFileHandler, name, log_directory)
-        handler.setLevel(logging.INFO)
-        if formatted:
-            formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-        else:
-            formatter = logging.Formatter('%(asctime)s - %(message)s')
-        handler.setFormatter(formatter)
+        handler = PluginHandler(logging.handlers.RotatingFileHandler,
+                                log_name or name, log_directory)
     else:
-        handler = logging.getLogger().handlers[0]
+        handler = logging.StreamHandler(sys.stdout)
+    handler.setLevel(logging.INFO)
+
+    if not formatted:
+        format_string = '%(message)s'
+    elif formatted == 'timestamp':
+        format_string = '%(asctime)s - %(message)s'
+    else:
+        format_string = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+    handler.setFormatter(logging.Formatter(format_string))
 
     log.addHandler(handler)
     return log

--- a/bartender/local_plugins/plugin_runner.py
+++ b/bartender/local_plugins/plugin_runner.py
@@ -158,7 +158,7 @@ class LocalPluginRunner(StoppableThread):
             # If they are not using a logger themselves, then we will simply log to
             # our standard logger
             if level_to_log is None:
-                self.logger.info(line.rstrip())
+                self.logger.log(logging.INFO, line.rstrip())
             # If they are using their own logger, then we will keep the format they have
             # by using a completely unformatted logger and logging at the level specified
             else:

--- a/bartender/local_plugins/plugin_runner.py
+++ b/bartender/local_plugins/plugin_runner.py
@@ -58,14 +58,16 @@ class LocalPluginRunner(StoppableThread):
 
         self.unique_name = '%s[%s]-%s' % (self.system.name, self.instance_name, self.system.version)
 
-        log_config = {'log_directory': self.plugin_log_directory, 'log_name': self.unique_name}
-        self.logger = getPluginLogger(self.unique_name, formatted=True,
-                                      **log_config)
-        self.unformatted_logger = getPluginLogger(self.unique_name+'-uf',
-                                                  formatted=False, **log_config)
-        self.timestamp_logger = getPluginLogger(self.unique_name+'-ts',
-                                                formatted='timestamp', **log_config)
         self.log_levels = getLogLevels()
+        log_config = {'log_directory': self.plugin_log_directory, 'log_name': self.unique_name}
+        self.unformatted_logger = getPluginLogger(self.unique_name+'-uf', **log_config)
+        self.timestamp_logger = getPluginLogger(self.unique_name+'-ts',
+                                                format_string='%(asctime)s - %(message)s',
+                                                **log_config)
+        self.logger = getPluginLogger(self.unique_name,
+                                      format_string='%(asctime)s - %(name)s - '
+                                                    '%(levelname)s - %(message)s',
+                                      **log_config)
 
         StoppableThread.__init__(self, logger=self.logger, name=self.unique_name)
 

--- a/requirements.in
+++ b/requirements.in
@@ -18,6 +18,7 @@ coverage
 flake8
 mock
 pytest
+pytest-mock
 pytz
 tox
 twine

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,7 @@ marshmallow==2.13.6
 mccabe==0.6.1             # via flake8
 mock==2.0.0
 mongoengine==0.14.3
+more-itertools==4.1.0     # via pytest
 pathtools==0.1.2          # via watchdog
 pbr==3.1.1                # via mock
 pika==0.11.2
@@ -41,7 +42,8 @@ pyflakes==1.6.0           # via flake8
 pygments==2.2.0           # via sphinx
 pymongo==3.5.1            # via mongoengine
 pyrabbit2==1.0.3
-pytest==3.4.2
+pytest==3.5.0
+pytest-mock==1.9.0
 python-box==3.1.1         # via yapconf
 pytz==2017.3
 pyyaml==3.12              # via watchdog

--- a/test/local_plugins/plugin_runner_test.py
+++ b/test/local_plugins/plugin_runner_test.py
@@ -1,71 +1,73 @@
 import logging
 import subprocess
 import sys
-import unittest
+import pytest
 
-from mock import Mock, PropertyMock, patch, ANY
+from mock import Mock, PropertyMock, call, patch, ANY
 from mongoengine import DoesNotExist
 
 from bartender.local_plugins.plugin_runner import LocalPluginRunner
 
 
-class PluginRunnerTest(unittest.TestCase):
+@pytest.fixture
+def instance_mock():
+    inst_mock = Mock(status='RUNNING')
+    type(inst_mock).name = PropertyMock(return_value='default')
+    return inst_mock
 
-    def setUp(self):
-        self.instance_mock = Mock(status='RUNNING')
-        type(self.instance_mock).name = PropertyMock(return_value='default')
-        self.system_mock = Mock(version='1.0.0', instances=[self.instance_mock])
-        type(self.system_mock).name = PropertyMock(return_value='system_name')
 
-        self.plugin = LocalPluginRunner('entry_point', self.system_mock, 'default',
-                                        '/path/to/plugin/name',
-                                        "web_host", 123, False)
+@pytest.fixture
+def system_mock(instance_mock):
+    sys_mock = Mock(version='1.0.0', instances=[instance_mock])
+    type(sys_mock).name = PropertyMock(return_value='system_name')
+    return sys_mock
 
-    def test_init_executable_script(self):
-        plugin = LocalPluginRunner('entry_point', self.system_mock, 'instance_name',
-                                   '/path/to/plugin/name',
-                                   "web_host", 123, False, plugin_args=['arg1', 'arg2'])
-        self.assertEqual(plugin.executable, [sys.executable, 'entry_point', 'arg1', 'arg2'])
 
-    def test_init_executable_package(self):
-        plugin = LocalPluginRunner('-m package', self.system_mock, 'instance_name',
-                                   '/path/to/plugin/name',
-                                   "web_host", 123, False, plugin_args=['arg1', 'arg2'])
-        self.assertEqual(plugin.executable, [sys.executable, '-m', 'package', 'arg1', 'arg2'])
+@pytest.fixture
+def plugin(system_mock):
+    return LocalPluginRunner('entry_point', system_mock, 'default',
+                             '/path/to/plugin/name', 'web_host', 123, False)
 
-    def test_get_status(self):
-        self.assertEqual('RUNNING', self.plugin.status)
-        self.assertTrue(self.instance_mock.reload.called)
+class TestPluginRunner(object):
 
-    def test_get_status_2(self):
-        self.instance_mock.status = 'STOPPED'
-        self.assertEqual('STOPPED', self.plugin.status)
-        self.assertTrue(self.instance_mock.reload.called)
+    @pytest.mark.parametrize('entry_point,expected', [
+        ('entry_point', [sys.executable, 'entry_point', 'arg1', 'arg2']),
+        ('-m package', [sys.executable, '-m', 'package', 'arg1', 'arg2']),
+    ])
+    def test_init_entry_point(self, system_mock, entry_point, expected):
+        plugin = LocalPluginRunner(entry_point, system_mock, 'instance_name',
+                                   '/path/to/plugin/name', "web_host", 123,
+                                   False, plugin_args=['arg1', 'arg2'])
+        assert plugin.executable == expected
 
-    def test_get_status_error(self):
-        self.instance_mock.reload.side_effect = DoesNotExist
-        self.assertEqual('UNKNOWN', self.plugin.status)
-        self.assertTrue(self.instance_mock.reload.called)
+    def test_unique_name(self, plugin):
+        assert plugin.unique_name == 'system_name[default]-1.0.0'
 
-    def test_set_status(self):
-        self.plugin.status = 'STOPPED'
-        self.assertEqual('STOPPED', self.instance_mock.status)
-        self.assertTrue(self.instance_mock.save.called)
+    def test_get_status(self, plugin, instance_mock):
+        assert plugin.status == 'RUNNING'
+        assert instance_mock.reload.called
 
-    def test_set_status_error(self):
-        self.instance_mock.reload.side_effect = DoesNotExist
-        self.plugin.status = 'STOPPED'
-        self.assertFalse(self.instance_mock.save.called)
+    def test_get_status_error(self, plugin, instance_mock):
+        instance_mock.reload.side_effect = DoesNotExist
+        assert plugin.status == 'UNKNOWN'
+        assert instance_mock.reload.called
 
-    def test_unique_name(self):
-        self.assertEqual('system_name[default]-1.0.0', self.plugin.unique_name)
+    def test_set_status(self, plugin, instance_mock):
+        plugin.status = 'STOPPED'
+        assert plugin.status == 'STOPPED'
+        assert instance_mock.save.called
 
-    def test_generate_plugin_environment(self):
+    def test_set_status_error(self, plugin, instance_mock):
+        instance_mock.reload.side_effect = DoesNotExist
+        plugin.status = 'STOPPED'
+        assert not instance_mock.save.called
+
+    def test_generate_plugin_environment(self, plugin):
         plugin_env = {
-            'BG_NAME': self.plugin.system.name,
-            'BG_VERSION': self.plugin.system.version,
-            'BG_INSTANCE_NAME': self.plugin.instance_name,
-            'BG_PLUGIN_PATH': self.plugin.path_to_plugin,
+            'BG_NAME': plugin.system.name,
+            'BG_VERSION': plugin.system.version,
+            'BG_INSTANCE_NAME': plugin.instance_name,
+            'BG_PLUGIN_PATH': plugin.path_to_plugin,
             'BG_WEB_HOST': 'web_host',
             'BG_WEB_PORT': '123',
             'BG_SSL_ENABLED': 'False',
@@ -74,140 +76,114 @@ class PluginRunnerTest(unittest.TestCase):
             'BG_CA_CERT': 'None'
         }
 
-        self.assertDictEqual(plugin_env, self.plugin._generate_plugin_environment())
+        assert plugin._generate_plugin_environment() == plugin_env
 
-    def test_generate_plugin_environment_no_copy_extra_bg_env(self):
-        generated_env = self.plugin._generate_plugin_environment()
-        self.assertNotIn('BG_foo', generated_env)
-        self.assertIn('BG_NAME', generated_env)
+    def test_generate_plugin_environment_no_copy_extra_bg_env(self, plugin):
+        generated_env = plugin._generate_plugin_environment()
+        assert 'BG_foo' not in generated_env
+        assert 'BG_NAME' in generated_env
 
-    def test_generate_plugin_environment_with_additional_environment(self):
-        self.plugin.environment = {'FOO': 'BAR'}
-        plugin_env = self.plugin._generate_plugin_environment()
-        self.assertEqual(plugin_env.get('FOO'), 'BAR')
+    def test_generate_plugin_environment_with_additional_environment(self, plugin):
+        plugin.environment = {'FOO': 'BAR'}
+        plugin_env = plugin._generate_plugin_environment()
+        assert plugin_env.get('FOO') == 'BAR'
 
-    @patch('bartender.local_plugins.plugin_runner.LocalPluginRunner._generate_plugin_environment',
-           Mock(return_value=1))
-    @patch('bartender.local_plugins.plugin_runner.Thread', Mock())
-    @patch('bartender.local_plugins.plugin_runner.subprocess.Popen')
-    def test_process_creation(self, process_mock):
+    def test_process_creation(self, mocker, plugin):
+        mocker.patch('bartender.local_plugins.plugin_runner.Thread')
+        env_mock = mocker.patch('bartender.local_plugins.plugin_runner.LocalPluginRunner._generate_plugin_environment')
+        process_mock = mocker.patch('bartender.local_plugins.plugin_runner.subprocess.Popen')
+
         stdout_mock = Mock(readline=Mock(return_value=b""))
         process_mock.return_value = Mock(poll=Mock(return_value="Not None"), stdout=stdout_mock)
 
-        self.plugin.run()
-        process_mock.assert_called_with(self.plugin.executable, env=1, bufsize=0,
-                                        stderr=subprocess.STDOUT,
+        plugin.run()
+        process_mock.assert_called_with(plugin.executable, env=env_mock(),
+                                        bufsize=0, stderr=subprocess.STDOUT,
                                         stdout=subprocess.PIPE, preexec_fn=ANY,
-                                        cwd=self.plugin.path_to_plugin)
+                                        cwd=plugin.path_to_plugin)
 
-    @patch('bartender.local_plugins.plugin_runner.LocalPluginRunner._generate_plugin_environment',
-           Mock())
-    @patch('bartender.local_plugins.plugin_runner.LocalPluginRunner.stopped',
-           Mock(return_value=True))
-    @patch('bartender.local_plugins.plugin_runner.subprocess.Popen')
-    @patch('bartender.local_plugins.plugin_runner.sleep')
-    @patch('bartender.local_plugins.plugin_runner.Thread')
-    def test_run_plugin_io_thread_successful_stop(self, thread_mock, sleep_mock, process_mock):
-        self.plugin.logger.error = Mock()
+    @pytest.mark.parametrize('process_poll,stopped,error_called', [
+        ([None, 0, 0], True, False),  # Successful stop
+        ([None, 1, 1], False, True),  # Bad stop
+    ])
+    def test_run_plugin_io_thread_stop(self, mocker, plugin, process_poll, stopped, error_called):
+        mocker.patch('bartender.local_plugins.plugin_runner.LocalPluginRunner._generate_plugin_environment')
+        thread_mock = mocker.patch('bartender.local_plugins.plugin_runner.Thread')
+        sleep_mock = mocker.patch('bartender.local_plugins.plugin_runner.sleep')
+        process_mock = mocker.patch('bartender.local_plugins.plugin_runner.subprocess.Popen')
+        stopped_mock = mocker.patch('bartender.local_plugins.plugin_runner.LocalPluginRunner.stopped',
+                                    Mock(return_value=stopped))
+
+        plugin.logger.error = Mock()
         fake_thread = Mock()
         thread_mock.return_value = fake_thread
-        process_mock.return_value.poll.side_effect = [None, 0, 0]
+        process_mock.return_value.poll.side_effect = process_poll
 
-        self.plugin.run()
-        self.assertEqual(0, self.plugin.logger.error.call_count)
-        thread_mock.assert_called_with(name=self.plugin.unique_name+'_io_thread',
-                                       target=self.plugin._check_io)
+        plugin.run()
+        assert plugin.logger.error.called == error_called
+        assert fake_thread.start.called
+        assert fake_thread.join.called
+        thread_mock.assert_called_with(name=plugin.unique_name+'_io_thread',
+                                       target=plugin._check_io)
         sleep_mock.assert_called_once_with(0.1)
-        fake_thread.start.assert_called_with()
-        fake_thread.join.assert_called_once_with()
 
-    @patch('bartender.local_plugins.plugin_runner.LocalPluginRunner._generate_plugin_environment',
-           Mock())
-    @patch('bartender.local_plugins.plugin_runner.LocalPluginRunner.stopped',
-           Mock(return_value=False))
-    @patch('bartender.local_plugins.plugin_runner.subprocess.Popen')
-    @patch('bartender.local_plugins.plugin_runner.sleep')
-    @patch('bartender.local_plugins.plugin_runner.Thread')
-    def test_run_plugin_io_thread_bad_stop(self, thread_mock, sleep_mock, process_mock):
-        self.plugin.logger.error = Mock()
-        fake_thread = Mock()
-        thread_mock.return_value = fake_thread
-        process_mock.return_value.poll.side_effect = [None, 1, 1]
+    @pytest.mark.parametrize('plugin_output,logger_calls', [
+        ([b"no logger", b""],
+            [call(logging.INFO, 'no logger')]
+        ),
+        ([b"ERROR: this is my error logger", b"INFO: this is my info logger", b""],
+            [
+                call(logging.ERROR, 'ERROR: this is my error logger'),
+                call(logging.INFO, 'INFO: this is my info logger'),
+            ]
+        ),
+    ])
+    def test_check_io(self, mocker, plugin, plugin_output, logger_calls):
+        mocker.patch('bartender.local_plugins.plugin_runner.LocalPluginRunner._generate_plugin_environment',
+                     Mock(return_value={}))
+        mocker.patch('bartender.local_plugins.plugin_runner.LocalPluginRunner.stopped',
+                     Mock(return_value=True))
+        thread_mock = mocker.patch('bartender.local_plugins.plugin_runner.Thread')
+        process_mock = mocker.patch('bartender.local_plugins.plugin_runner.subprocess.Popen')
 
-        self.plugin.run()
-        self.plugin.logger.error.assert_called()
-        thread_mock.assert_called_with(name=self.plugin.unique_name+'_io_thread',
-                                       target=self.plugin._check_io)
-        sleep_mock.assert_called_once_with(0.1)
-        fake_thread.start.assert_called_with()
-        fake_thread.join.assert_called_once_with()
-
-    @patch('bartender.local_plugins.plugin_runner.LocalPluginRunner._generate_plugin_environment',
-           Mock(return_value={}))
-    @patch('bartender.local_plugins.plugin_runner.LocalPluginRunner.stopped',
-           Mock(return_value=True))
-    @patch('bartender.local_plugins.plugin_runner.subprocess.Popen')
-    @patch('bartender.local_plugins.plugin_runner.Thread')
-    def test_check_io_no_custom_logger_used(self, thread_mock, process_mock):
-        stdout_mock = Mock(name='stdout mock', readline=Mock(side_effect=[b"no logger", b""]))
+        stdout_mock = Mock(name='stdout mock', readline=Mock(side_effect=plugin_output))
         process_mock.return_value = Mock(name='process mock', poll=Mock(return_value=0),
                                          stdout=stdout_mock)
-        thread_mock.return_value = Mock(name='thread mock', join=self.plugin._check_io)
-        self.plugin.logger = Mock()
+        thread_mock.return_value = Mock(name='thread mock', join=plugin._check_io)
+        plugin.logger = Mock()
 
-        self.plugin.run()
-        self.plugin.logger.info.assert_any_call('no logger'.rstrip())
+        plugin.run()
+        plugin.logger.log.assert_has_calls(logger_calls)
 
-    @patch('bartender.local_plugins.plugin_runner.LocalPluginRunner._generate_plugin_environment',
-           Mock(return_value={}))
-    @patch('bartender.local_plugins.plugin_runner.LocalPluginRunner.stopped',
-           Mock(return_value=True))
-    @patch('bartender.local_plugins.plugin_runner.subprocess.Popen')
-    @patch('bartender.local_plugins.plugin_runner.Thread')
-    def test_check_io_custom_logger_being_used(self, thread_mock, process_mock):
-        stdout_mock = Mock(name='stdout mock', readline=Mock(
-            side_effect=[
-                b"ERROR: this is my error logger", b"INFO: this is my info logger", b""]))
-        process_mock.return_value = Mock(name='process mock', poll=Mock(return_value=0),
-                                         stdout=stdout_mock)
-        thread_mock.return_value = Mock(name='thread mock', join=self.plugin._check_io)
-        self.plugin.logger = Mock()
-
-        self.plugin.run()
-        self.plugin.logger.log.assert_any_call(logging.ERROR, "ERROR: this is my error logger")
-        self.plugin.logger.log.assert_any_call(logging.INFO, "INFO: this is my info logger")
-
-    def test_check_io_multiple_calls(self):
+    def test_check_io_multiple_calls(self, plugin):
         stdout_mock = Mock(name='stdout mock', readline=Mock(
             side_effect=[
                 b"ERROR: this is my error logger", b"INFO: this is my info logger", b"", b""]))
-        check_io_mock = Mock(wraps=self.plugin._check_io)
+        check_io_mock = Mock(wraps=plugin._check_io)
         logger_mock = Mock()
-        self.plugin.process = Mock(name='process mock', poll=Mock(side_effect=[None, 0, 0]),
-                                   stdout=stdout_mock)
-        self.plugin._check_io = check_io_mock
-        self.plugin.logger = logger_mock
+        plugin.process = Mock(name='process mock', poll=Mock(side_effect=[None, 0, 0]),
+                              stdout=stdout_mock)
+        plugin._check_io = check_io_mock
+        plugin.logger = logger_mock
 
-        self.plugin._check_io()
-        self.assertLess(1, check_io_mock.call_count)
-        logger_mock.log.assert_any_call(logging.ERROR, "ERROR: this is my error logger")
-        logger_mock.log.assert_any_call(logging.INFO, "INFO: this is my info logger")
+        plugin._check_io()
+        assert check_io_mock.call_count > 1
 
-    @patch('bartender.local_plugins.plugin_runner.subprocess.Popen',
-           Mock(side_effect=ValueError('error_message')))
-    @patch('bartender.local_plugins.plugin_runner.LocalPluginRunner._generate_plugin_environment',
-           Mock())
-    def test_run_call_throw_exception(self):
-        self.plugin.logger.error = Mock()
-        self.plugin.run()
-        self.plugin.logger.error.assert_called_with('error_message')
+    def test_run_call_throw_exception(self, mocker, plugin):
+        mocker.patch('bartender.local_plugins.plugin_runner.subprocess.Popen',
+            Mock(side_effect=ValueError('error_message')))
+        mocker.patch('bartender.local_plugins.plugin_runner.LocalPluginRunner._generate_plugin_environment')
 
-    def test_kill_process(self):
-        self.plugin.process = Mock(poll=Mock(return_value=None))
-        self.plugin.kill()
-        self.assertEqual(self.plugin.process.kill.call_count, 1)
+        plugin.logger.error = Mock()
+        plugin.run()
+        plugin.logger.error.assert_called_with('error_message')
 
-    def test_kill_process_dead(self):
-        self.plugin.process = Mock(poll=Mock(return_value="dead"))
-        self.plugin.kill()
-        self.assertEqual(self.plugin.process.kill.call_count, 0)
+    def test_kill_process(self, plugin):
+        plugin.process = Mock(poll=Mock(return_value=None))
+        plugin.kill()
+        assert plugin.process.kill.called
+
+    def test_kill_process_dead(self, plugin):
+        plugin.process = Mock(poll=Mock(return_value="dead"))
+        plugin.kill()
+        assert not plugin.process.kill.called


### PR DESCRIPTION
This fixes beer-garden/beer-garden#57.

How we handle output from the plugins is now more explicit. Previously we had one logger in the PluginRunner, now we have three.

Logging generated by the PluginRunner itself will use the 'normal' log formatting - timestamp, level, logger name, message.

Logging that gets pulled out of the plugin subprocess will use one of two loggers:
- If we can't find a level in the message then we will log using the `timestamp` logger. This adds a timestamp to the message but otherwise just passes the message through. Since we have no idea what the 'true' level should be we log these at the `ERROR` level to ensure they get outputted (but that level is *not* part of the log message).
- If we do fine a level then we assume the plugin is using its own logger with its own formatter. We will log the message at the level we found but will not mangle the message in any way.

Also, the formatting no longer changes based on if you're logging to a plugin log file or STDOUT. I think that causes a good amount of confusion (at least it did for me), but it does make it harder to interpret what's happening if you're looking at STDOUT with a bunch of plugins running at the same time. It would be easy to switch back.

I also converted some tests to pytest style.