### PR TITLE
Updated queue deletion/clearing.

### DIFF
--- a/bartender/pyrabbit.py
+++ b/bartender/pyrabbit.py
@@ -5,6 +5,8 @@ from pyrabbit2.http import HTTPError, NetworkError
 
 from bg_utils.parser import BeerGardenSchemaParser
 
+import bartender
+
 
 class PyrabbitClient(object):
     """Class that implements a connection to RabbitMQ Management HTTP API"""
@@ -68,8 +70,7 @@ class PyrabbitClient(object):
                     request = BeerGardenSchemaParser.parse_request(message['payload'],
                                                                    from_string=True)
                     self.logger.debug("Canceling Request: %s", request.id)
-                    request.status = 'CANCELED'
-                    request.save()
+                    bartender.bv_client.update_request(request.id, status='CANCELED')
                 except Exception as ex:
                     self.logger.error('Error removing message:')
                     self.logger.exception(ex)

--- a/bin/app.sh
+++ b/bin/app.sh
@@ -3,7 +3,7 @@
 SCRIPT_DIRECTORY="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 APP_ROOT="$(dirname "$SCRIPT_DIRECTORY")"
 
-CONFIG_FILE="$APP_ROOT/dev_conf/config.json"
+CONFIG_FILE="$APP_ROOT/dev_conf/config.yml"
 
 CMD="bartender -c $CONFIG_FILE"
 python -m $CMD

--- a/test/pyrabbit_test.py
+++ b/test/pyrabbit_test.py
@@ -79,15 +79,15 @@ class PyrabbitClientTest(unittest.TestCase):
         self.assertFalse(self.client_mock.get_messages.called)
 
     @patch('bartender.pyrabbit.BeerGardenSchemaParser')
-    def test_clear_queue(self, parser_mock):
+    @patch('bartender.bv_client')
+    def test_clear_queue(self, bv_client_mock, parser_mock):
         fake_request = Mock(id='id', status='CREATED')
         parser_mock.parse_request.return_value = fake_request
         self.client_mock.get_queue.return_value = {'messages_ready': 1}
         self.client_mock.get_messages.return_value = [{'payload': fake_request}]
 
         self.client.clear_queue('queue')
-        self.assertEqual(fake_request.status, 'CANCELED')
-        self.assertTrue(fake_request.save.called)
+        bv_client_mock.update_request.assert_called_with('id', status='CANCELED')
         parser_mock.parse_request.assert_called_with(fake_request, from_string=True)
 
     @patch('bartender.pyrabbit.BeerGardenSchemaParser')


### PR DESCRIPTION
This is to solve possible problems for keeping gauges around: beer-garden/beer-garden#69

This update relies on setting the request status to canceled
via the ReST API. This has been causing us a couple of edge
case problems and sending the data back through the normal
data path should clear up a lot of things.

In particular, it is hard to keep gauges accurate without
this change.