### PR TITLE
Fixes #4

### DIFF
--- a/bartender/local_plugins/loader.py
+++ b/bartender/local_plugins/loader.py
@@ -133,7 +133,8 @@ class LocalPluginLoader(object):
                                        plugin_log_directory=plugin_log_directory,
                                        url_prefix=bartender.config.web.url_prefix,
                                        ca_verify=bartender.config.web.ca_verify,
-                                       ca_cert=bartender.config.web.ca_cert)
+                                       ca_cert=bartender.config.web.ca_cert,
+                                       log_level=config['LOG_LEVEL'])
 
             self.registry.register_plugin(plugin)
             plugin_list.append(plugin)
@@ -148,6 +149,8 @@ class LocalPluginLoader(object):
 
         instances = getattr(config_module, 'INSTANCES', None)
         plugin_args = getattr(config_module, 'PLUGIN_ARGS', None)
+        user_log_level = getattr(config_module, 'LOG_LEVEL', 'INFO')
+        log_level = self._convert_log_level(user_log_level)
 
         if instances is None and plugin_args is None:
             instances = ['default']
@@ -185,10 +188,17 @@ class LocalPluginLoader(object):
             'DISPLAY_NAME': getattr(config_module, 'DISPLAY_NAME', None),
             'REQUIRES': getattr(config_module, 'REQUIRES', []),
             'ENVIRONMENT': getattr(config_module, 'ENVIRONMENT', {}),
-            'METADATA': getattr(config_module, 'METADATA', {})
+            'METADATA': getattr(config_module, 'METADATA', {}),
+            'LOG_LEVEL': log_level,
         }
 
         if 'BGPLUGINCONFIG' in sys.modules:
             del sys.modules['BGPLUGINCONFIG']
 
         return config
+
+    def _convert_log_level(self, level_name):
+        try:
+            return getattr(logging, str(level_name).upper())
+        except AttributeError:
+            return logging.INFO

--- a/bartender/local_plugins/logger.py
+++ b/bartender/local_plugins/logger.py
@@ -21,7 +21,13 @@ class PluginHandler(object):
 
 
 # Since we are imitating the logging module, we will allow camel case method names
-def getPluginLogger(name, format_string=None, log_directory=None, log_name=None):
+def getPluginLogger(
+        name,
+        format_string=None,
+        log_directory=None,
+        log_name=None,
+        log_level=None,
+):
     """Get a logger for a plugin
 
     Args:
@@ -33,10 +39,14 @@ def getPluginLogger(name, format_string=None, log_directory=None, log_name=None)
         log_name (str, optional): The name of the log file
             * If ``log_directory`` is not provided this is not used
             * If not provided the ``name`` value will be used
+        log_level (int, optional): Log level for this logger/handler pair.
+            If none are set, then the current effective level will be used.
 
      Returns:
         The configured logger instance
     """
+    if log_level is None:
+        log_level = logging.getLogger(__name__).getEffectiveLevel()
     log = logging.getLogger(name)
     log.propagate = False
     if len(log.handlers) > 0:
@@ -48,9 +58,10 @@ def getPluginLogger(name, format_string=None, log_directory=None, log_name=None)
     else:
         handler = logging.StreamHandler(sys.stdout)
 
-    handler.setLevel(logging.INFO)
+    handler.setLevel(log_level)
     handler.setFormatter(logging.Formatter(format_string))
     log.addHandler(handler)
+    log.setLevel(log_level)
 
     return log
 

--- a/bartender/local_plugins/plugin_runner.py
+++ b/bartender/local_plugins/plugin_runner.py
@@ -25,7 +25,8 @@ class LocalPluginRunner(StoppableThread):
 
     def __init__(self, entry_point, system, instance_name, path_to_plugin, web_host, web_port,
                  ssl_enabled, plugin_args=None, environment=None, requirements=None,
-                 plugin_log_directory=None, url_prefix=None, ca_verify=True, ca_cert=None):
+                 plugin_log_directory=None, url_prefix=None, ca_verify=True, ca_cert=None,
+                 **kwargs):
 
         self.entry_point = entry_point
         self.system = system
@@ -41,6 +42,10 @@ class LocalPluginRunner(StoppableThread):
         self.url_prefix = url_prefix
         self.ca_verify = ca_verify
         self.ca_cert = ca_cert
+        if 'log_level' in kwargs:
+            self.plugin_default_log_level = kwargs['log_level']
+        else:
+            self.plugin_default_log_level = logging.INFO
 
         for instance in self.system.instances:
             if instance.name == self.instance_name:
@@ -60,14 +65,19 @@ class LocalPluginRunner(StoppableThread):
 
         self.log_levels = getLogLevels()
         log_config = {'log_directory': self.plugin_log_directory, 'log_name': self.unique_name}
+
+        # Logger used for bartender purposes.
+        self.logger = getPluginLogger(
+            self.unique_name,
+            format_string='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+            **log_config
+        )
+
+        log_config['log_level'] = self.plugin_default_log_level
         self.unformatted_logger = getPluginLogger(self.unique_name+'-uf', **log_config)
         self.timestamp_logger = getPluginLogger(self.unique_name+'-ts',
                                                 format_string='%(asctime)s - %(message)s',
                                                 **log_config)
-        self.logger = getPluginLogger(self.unique_name,
-                                      format_string='%(asctime)s - %(name)s - '
-                                                    '%(levelname)s - %(message)s',
-                                      **log_config)
 
         StoppableThread.__init__(self, logger=self.logger, name=self.unique_name)
 
@@ -195,7 +205,8 @@ class LocalPluginRunner(StoppableThread):
             'BG_SSL_ENABLED': self.ssl_enabled,
             'BG_URL_PREFIX': self.url_prefix,
             'BG_CA_VERIFY': self.ca_verify,
-            'BG_CA_CERT': self.ca_cert
+            'BG_CA_CERT': self.ca_cert,
+            'BG_LOG_LEVEL': logging.getLevelName(self.plugin_default_log_level),
         }
 
         for key, value in plugin_env.items():

--- a/test/local_plugins/plugin_runner_test.py
+++ b/test/local_plugins/plugin_runner_test.py
@@ -63,6 +63,18 @@ class TestPluginRunner(object):
         plugin.status = 'STOPPED'
         assert not instance_mock.save.called
 
+    def test_plugin_loggers_levels(self, plugin, system_mock):
+        # We have to null out the handlers, otherwise we will end up
+        # using a cached handler.
+        plugin.unformatted_logger.handlers = []
+        plugin.timestamp_logger.handlers = []
+        runner = LocalPluginRunner(
+            'entry_point', system_mock, 'default', '/path/to/plugin/name',
+            'web_host', 123, False, log_level=logging.DEBUG)
+        assert runner.logger.level == logging.getLogger(__name__).getEffectiveLevel()
+        assert runner.unformatted_logger.level == logging.DEBUG
+        assert runner.timestamp_logger.level == logging.DEBUG
+
     def test_generate_plugin_environment(self, plugin):
         plugin_env = {
             'BG_NAME': plugin.system.name,
@@ -74,7 +86,8 @@ class TestPluginRunner(object):
             'BG_SSL_ENABLED': 'False',
             'BG_URL_PREFIX': 'None',
             'BG_CA_VERIFY': 'True',
-            'BG_CA_CERT': 'None'
+            'BG_CA_CERT': 'None',
+            'BG_LOG_LEVEL': 'INFO',
         }
 
         assert plugin._generate_plugin_environment() == plugin_env


### PR DESCRIPTION
We had to change the default logging level from INFO to whatever
they set, or the system level. For the plugin runner, the
default logger (i.e. the one that bartender uses) should default
to whatever the system is set to.

However, the timestamp and unformatted loggers now use the level
specified by the plugin developer (INFO by default). The log
level is then set in the environment for the plugin. As a result
changes will need to happen in brewtils.