### PR TITLE
Adding admin queue expiration policy

### DIFF
--- a/bartender/app.py
+++ b/bartender/app.py
@@ -104,6 +104,9 @@ class BartenderApp(StoppableThread):
         self.logger.info("Verifying message virtual host...")
         self.clients['pyrabbit'].verify_virtual_host()
 
+        self.logger.info("Ensuring admin queue expiration policy...")
+        self.clients['pyrabbit'].ensure_admin_expiry()
+
         self.logger.info("Declaring message exchange...")
         self.clients['pika'].declare_exchange()
 

--- a/bartender/specification.py
+++ b/bartender/specification.py
@@ -38,6 +38,11 @@ SPECIFICATION = {
                 "description": "Hostname of AMQ to use",
                 "previous_names": ["amq_host"],
             },
+            "admin_queue_expiry": {
+                "type": "int",
+                "default": 3600000,     # One hour
+                "description": "Time before unused admin queues are removed",
+            },
             "heartbeat_interval": {
                 "type": "int",
                 "default": 3600,


### PR DESCRIPTION
This fixes beer-garden/beer-garden#101

It adds an expiration to the admin queues themselves. See https://www.rabbitmq.com/ttl.html#queue-ttl:

> This controls for how long a queue can be unused before it is automatically deleted. Unused means the queue has no consumers, the queue has not been redeclared, and basic.get has not been invoked for a duration of at least the expiration period.

So the default behavior will be to remove the admin queue if it hasn't been used in one hour.