### PR TITLE
Transitioning to thriftpy2 as thriftpy is deprecated

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -67,7 +67,7 @@ sphinx-rtd-theme==0.4.1
 sphinx==1.7.6
 sphinxcontrib-websupport==1.1.0  # via sphinx
 subprocess32==3.5.2 ; python_version < "3.0"
-thriftpy==0.3.9
+thriftpy2==0.3.11
 tox==3.1.3
 tqdm==4.24.0              # via twine
 twine==1.11.0


### PR DESCRIPTION
This helps with beer-garden/beer-garden#175 (Python 3.7 support)