### PR TITLE
Wrapping plugin loading in try block

### DIFF
--- a/bartender/local_plugins/loader.py
+++ b/bartender/local_plugins/loader.py
@@ -25,7 +25,12 @@ class LocalPluginLoader(object):
         the plugin can be loaded correctly.
         """
         for plugin_path in self.scan_plugin_path():
-            self.load_plugin(plugin_path)
+            try:
+                self.load_plugin(plugin_path)
+            except Exception as ex:
+                self.logger.exception(
+                    "Exception while loading plugin %s: %s", plugin_path, ex
+                )
 
         self.validate_plugin_requirements()
 

--- a/test/local_plugins/loader_test.py
+++ b/test/local_plugins/loader_test.py
@@ -59,6 +59,16 @@ class PluginLoaderTest(unittest.TestCase):
         self.assertFalse(load_plugin_mock.called)
         validate_mock.assert_called_once_with()
 
+    @patch('bartender.local_plugins.loader.LocalPluginLoader.scan_plugin_path',
+           Mock(return_value=['pl1', 'pl2']))
+    @patch('bartender.local_plugins.loader.LocalPluginLoader.validate_plugin_requirements')
+    @patch('bartender.local_plugins.loader.LocalPluginLoader.load_plugin')
+    def test_load_plugins_exception(self, load_plugin_mock, validate_mock):
+        load_plugin_mock.side_effect = [ValueError()]
+        self.loader.load_plugins()
+        load_plugin_mock.assert_has_calls([call('pl1'), call('pl2')], any_order=False)
+        validate_mock.assert_called_once_with()
+
     @patch('bartender.local_plugins.loader.listdir', Mock(return_value=['file1', 'file2']))
     @patch('bartender.local_plugins.loader.isfile', Mock(side_effect=[False, True]))
     @patch('bartender.local_plugins.loader.LocalPluginLoader.load_plugin', Mock())


### PR DESCRIPTION
This fixes beer-garden/beer-garden#202.

Trying to replicate this exactly failed because a missing VERSION key in the beer.conf is caught during configuration validation.

However, one plugin loading raising an exception shouldn't affect the loading of other plugins, so I think this fix is warranted.