### PR TITLE
Issue/325

### DIFF
--- a/test/request_validator_test.py
+++ b/test/request_validator_test.py
@@ -472,6 +472,41 @@ class TestValidateParameterType(object):
 
 class TestValidateChoices(object):
     @pytest.mark.parametrize(
+        "req,choices",
+        [
+            (
+                make_request(parameters={"p1": "a"}),
+                Mock(type="static", value=["a", "b"]),
+            ),
+            (
+                make_request(parameters={"p1": "b"}),
+                Mock(type="static", value=["a", "b"]),
+            ),
+            (
+                make_request(parameters={"p1": "a"}),
+                Mock(
+                    type="static",
+                    value=[{"value": "a", "text": "A"}, {"value": "b", "text": "B"}],
+                ),
+            ),
+            (
+                make_request(parameters={"p1": "a"}),
+                Mock(type="static", value=["a", {"value": "b", "text": "B"}]),
+            ),
+            (
+                make_request(parameters={"p1": "b"}),
+                Mock(type="static", value=["a", {"value": "b", "text": "B"}]),
+            ),
+        ],
+    )
+    def test_simple(self, validator, req, choices):
+        command = Mock(
+            parameters=[make_param(key="p1", choices=choices, optional=False)]
+        )
+
+        validator.get_and_validate_parameters(req, command)
+
+    @pytest.mark.parametrize(
         "req",
         [
             make_request(parameters={"p2": "7"}),
@@ -498,33 +533,6 @@ class TestValidateChoices(object):
                     ),
                 ),
             ]
-        )
-
-        validator.get_and_validate_parameters(req, command)
-
-    @pytest.mark.parametrize(
-        "req,choices",
-        [
-            (
-                make_request(parameters={"p1": "a"}),
-                Mock(type="static", value=["a", "b"]),
-            ),
-            (
-                make_request(parameters={"p1": "b"}),
-                Mock(type="static", value=["a", "b"]),
-            ),
-            (
-                make_request(parameters={"p1": "a"}),
-                Mock(
-                    type="static",
-                    value=[{"value": "a", "text": "A"}, {"value": "b", "text": "B"}],
-                ),
-            ),
-        ],
-    )
-    def test_validate_choices_list(self, validator, req, choices):
-        command = Mock(
-            parameters=[make_param(key="p1", choices=choices, optional=False)]
         )
 
         validator.get_and_validate_parameters(req, command)

--- a/test/request_validator_test.py
+++ b/test/request_validator_test.py
@@ -503,6 +503,33 @@ class TestValidateChoices(object):
         validator.get_and_validate_parameters(req, command)
 
     @pytest.mark.parametrize(
+        "req,choices",
+        [
+            (
+                make_request(parameters={"p1": "a"}),
+                Mock(type="static", value=["a", "b"]),
+            ),
+            (
+                make_request(parameters={"p1": "b"}),
+                Mock(type="static", value=["a", "b"]),
+            ),
+            (
+                make_request(parameters={"p1": "a"}),
+                Mock(
+                    type="static",
+                    value=[{"value": "a", "text": "A"}, {"value": "b", "text": "B"}],
+                ),
+            ),
+        ],
+    )
+    def test_validate_choices_list(self, validator, req, choices):
+        command = Mock(
+            parameters=[make_param(key="p1", choices=choices, optional=False)]
+        )
+
+        validator.get_and_validate_parameters(req, command)
+
+    @pytest.mark.parametrize(
         "req",
         [
             make_request(parameters={"p2": "1"}),


### PR DESCRIPTION
This fixes beer-garden/beer-garden#325.

This fixes a bug where the request validator was not properly respecting choices that specified an alternate display text for static choices.

This PR fixes that by taking the parsing that was previously partially duplicated across the url and command choice types and using that for all types.

This has the nice side-effect of a removing a limitation of command choices. Previously, all choice options needed to be either a value or a value/text dict. Now they can be mixed (so if there's only one value that you'd like to have an alternate text, that's now easier).