### PR TITLE
Remove Caching from Pruner

### DIFF
--- a/bartender/local_plugins/env_help.py
+++ b/bartender/local_plugins/env_help.py
@@ -52,7 +52,7 @@ def is_string_environment_variable(string):
 
 
 def get_environment_var_name_from_string(string):
-    """ Strips out the Variable name from a string
+    """Strips out the Variable name from a string
     :param string: e.g. $MY_PATH:$YOUR_PATH
     :return string: e.g. MY_PATH
     """

--- a/bartender/mongo_pruner.py
+++ b/bartender/mongo_pruner.py
@@ -44,6 +44,6 @@ class MongoPruner(StoppableThread):
                     "Removing %ss older than %s"
                     % (task["collection"].__name__, str(delete_older_than))
                 )
-                task["collection"].objects(query).delete()
+                task["collection"].objects(query).no_cache().delete()
 
         self.logger.info(self.display_name + " is stopped")

--- a/test/mongo_pruner_test.py
+++ b/test/mongo_pruner_test.py
@@ -30,3 +30,4 @@ class MongoPrunerTest(unittest.TestCase):
 
         self.mongo_pruner.run()
         self.assertTrue(self.collection_mock.objects.return_value.no_cache.called)
+        self.assertTrue(self.collection_mock.objects.return_value.no_cache.return_value.delete.called)

--- a/test/mongo_pruner_test.py
+++ b/test/mongo_pruner_test.py
@@ -30,4 +30,5 @@ class MongoPrunerTest(unittest.TestCase):
 
         self.mongo_pruner.run()
         self.assertTrue(self.collection_mock.objects.return_value.no_cache.called)
-        self.assertTrue(self.collection_mock.objects.return_value.no_cache.return_value.delete.called)
+        self.assertTrue(self.collection_mock.objects.return_value.
+                        no_cache.return_value.delete.called)

--- a/test/mongo_pruner_test.py
+++ b/test/mongo_pruner_test.py
@@ -29,4 +29,4 @@ class MongoPrunerTest(unittest.TestCase):
         self.mongo_pruner._stop_event = Mock(wait=Mock(side_effect=[False, True]))
 
         self.mongo_pruner.run()
-        self.assertTrue(self.collection_mock.objects.return_value.delete.called)
+        self.assertTrue(self.collection_mock.objects.return_value.no_cache.called)


### PR DESCRIPTION
When the Pruner deletes the collection objects, they are staying cached in memory until MongoEngine de allocates them from memeory. By setting the `no_cache()` function, after the objects are iterated through (`delete()`), then drops them from memory. 

fixes beer-garden/beer-garden#604

Test Example:
120k Requests
4GB of RAM

Prior: 
Pre-Execute = 1.17GB Free
Execute = .11GB Free (lowest drop)
Post-Execute = .11GB Free

W/ Fix:
Pre-Execute = 1.18GB Free
Execute = .86GB Free (lowest drop)
Post-Execute = 1.03GB Free